### PR TITLE
Replace deprecated HTML-ENTITIES conversion in DOM loader

### DIFF
--- a/src/Domfactory/Domain/Dom.php
+++ b/src/Domfactory/Domain/Dom.php
@@ -56,9 +56,9 @@ class Dom
     /**
      * DOM factory constructor
      *
-     * @param HtmlParserInterface $htmlParser HTML parser
+     * @param HtmlParserInterface|null $htmlParser HTML parser
      */
-    public function __construct(HtmlParserInterface $htmlParser = null)
+    public function __construct(?HtmlParserInterface $htmlParser = null)
     {
         $this->htmlParser = $htmlParser ?: new HtmlParser();
     }

--- a/src/Domfactory/Domain/Dom.php
+++ b/src/Domfactory/Domain/Dom.php
@@ -72,7 +72,8 @@ class Dom
      */
     public function load($source)
     {
-        $source = mb_convert_encoding($source, 'HTML-ENTITIES', mb_detect_encoding($source));
+        $encoding = mb_detect_encoding($source, mb_detect_order(), true) ?: 'UTF-8';
+        $source   = mb_encode_numericentity($source, [0x80, 0x10FFFF, 0, 0xFFFF], $encoding);
         $dom    = new DOMDocument();
 
         // Try to load the source as standard XML document first, then as HTML document


### PR DESCRIPTION
• Removed the deprecated mb_convert_encoding(..., 'HTML-ENTITIES', ...) call in Dom::load.
• Added explicit encoding detection with a safe UTF‑8 fallback.
• Converted to numeric entities using mb_encode_numericentity, preserving entity-safe parsing without relying on deprecated mbstring behavior.